### PR TITLE
Display packages errors

### DIFF
--- a/lib/installed-packages-panel.js
+++ b/lib/installed-packages-panel.js
@@ -201,7 +201,7 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
 
       this.matchPackages()
     }).catch((error) => {
-      console.error(error.message, error.stack)
+      this.refs.updateErrors.appendChild(new ErrorView(this.packageManager, error).element)
     })
   }
 


### PR DESCRIPTION
Package errors were being logged instead of shown in UI. Fixes #11.