### PR TITLE
Rename updateErrors to packageErrors in packages panel

### DIFF
--- a/lib/installed-packages-panel.js
+++ b/lib/installed-packages-panel.js
@@ -41,7 +41,7 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
       this.refs.filterEditor.onDidStopChanging(() => { this.matchPackages() })
     )
     this.subscriptions.add(
-      this.packageManager.on('package-install-failed theme-install-failed package-uninstall-failed theme-uninstall-failed package-update-failed theme-update-failed', ({pack, error}) => {
+      this.packageManager.on('package-install-failed package-uninstall-failed package-update-failed', ({pack, error}) => {
         this.refs.packageErrors.appendChild(new ErrorView(this.packageManager, error).element)
       })
     )

--- a/lib/installed-packages-panel.js
+++ b/lib/installed-packages-panel.js
@@ -42,7 +42,7 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
     )
     this.subscriptions.add(
       this.packageManager.on('package-install-failed theme-install-failed package-uninstall-failed theme-uninstall-failed package-update-failed theme-update-failed', ({pack, error}) => {
-        this.refs.updateErrors.appendChild(new ErrorView(this.packageManager, error).element)
+        this.refs.packageErrors.appendChild(new ErrorView(this.packageManager, error).element)
       })
     )
 
@@ -95,7 +95,7 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
               <TextEditor ref='filterEditor' mini placeholderText='Filter packages by name' />
             </div>
 
-            <div ref='updateErrors' />
+            <div ref='packageErrors' />
 
             <section className='sub-section installed-packages'>
               <h3 ref='communityPackagesHeader' className='sub-section-heading icon icon-package'>
@@ -201,7 +201,7 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
 
       this.matchPackages()
     }).catch((error) => {
-      console.error(error.message, error.stack)
+      this.refs.packageErrors.appendChild(new ErrorView(this.packageManager, error).element)
     })
   }
 


### PR DESCRIPTION
As suggested in #13, the errors element needs a more descriptive name. Also this is more consistent with the other panels.