### PR TITLE
Fix links

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -91,7 +91,7 @@ export default class PackageDetailView {
 
     const learnMoreButtonClickHandler = (event) => {
       event.preventDefault()
-      shell.openExternal(`https://pulsar-edit.dev/packages/${this.pack.name}`)
+      shell.openExternal(`https://web.pulsar-edit.dev/packages/${this.pack.name}`)
     }
     this.refs.learnMoreButton.addEventListener('click', learnMoreButtonClickHandler)
     this.disposables.add(new Disposable(() => { this.refs.learnMoreButton.removeEventListener('click', learnMoreButtonClickHandler) }))
@@ -273,7 +273,7 @@ export default class PackageDetailView {
               <p ref='startupTime' className='text icon icon-dashboard hidden' tabIndex='-1' />
 
               <div ref='buttons' className='btn-wrap-group hidden'>
-                <button ref='learnMoreButton' className='btn btn-default icon icon-link'>View on Atom.io</button>
+                <button ref='learnMoreButton' className='btn btn-default icon icon-link'>View on pulsar-edit.dev</button>
                 <button ref='issueButton' className='btn btn-default icon icon-bug'>Report Issue</button>
                 <button ref='changelogButton' className='btn btn-default icon icon-squirrel'>CHANGELOG</button>
                 <button ref='licenseButton' className='btn btn-default icon icon-law'>LICENSE</button>


### PR DESCRIPTION
Renamed the "View on Atom.io" button to "View on pulsar-edit.dev" and fixed the URL to the actual package website link (was missing the "web" bit).